### PR TITLE
Fix invalid descriptor for Type(String dotPath) with primitive dot path

### DIFF
--- a/src/main/java/mx/kenzie/foundation/Type.java
+++ b/src/main/java/mx/kenzie/foundation/Type.java
@@ -12,7 +12,7 @@ public record Type(String dotPath, String descriptor, String internalName)
     implements java.lang.reflect.Type, TypeDescriptor {
     
     public Type(String dotPath) {
-        this(dotPath, "L" + dotPath.replace(".", "/") + ";", dotPath.replace(".", "/"));
+        this(dotPath, getDescriptor(dotPath), dotPath.replace(".", "/"));
     }
     
     public Type(Class<?> cls) {

--- a/src/main/java/mx/kenzie/foundation/Type.java
+++ b/src/main/java/mx/kenzie/foundation/Type.java
@@ -26,6 +26,13 @@ public record Type(String dotPath, String descriptor, String internalName)
     private static String getInternalName(final java.lang.reflect.Type type) {
         return type.getTypeName().replace('.', '/');
     }
+
+    private static String getDescriptor(final String dotPath) {
+        return org.objectweb.asm.Type.getType(switch (dotPath) {
+            case "byte", "short", "int", "char", "boolean", "double", "float", "long", "void" -> dotPath;
+            default -> "L" + dotPath.replace('.', '/') + ";";
+        }).getDescriptor();
+    }
     
     public static Type[] of(Class<?>... classes) {
         final Type[] types = new Type[classes.length];

--- a/src/main/java/mx/kenzie/foundation/Type.java
+++ b/src/main/java/mx/kenzie/foundation/Type.java
@@ -12,7 +12,7 @@ public record Type(String dotPath, String descriptor, String internalName)
     implements java.lang.reflect.Type, TypeDescriptor {
     
     public Type(String dotPath) {
-        this(dotPath, "L" + dotPath.replace(".", "/") + ";", dotPath.replace(".", "/"));
+        this(dotPath, getDescriptor(dotPath), dotPath.replace(".", "/"));
     }
     
     public Type(Class<?> cls) {
@@ -25,6 +25,21 @@ public record Type(String dotPath, String descriptor, String internalName)
     
     private static String getInternalName(final java.lang.reflect.Type type) {
         return type.getTypeName().replace('.', '/');
+    }
+
+    private static String getDescriptor(final String dotPath) {
+        return (switch (dotPath) {
+            case "byte" -> org.objectweb.asm.Type.BYTE_TYPE;
+            case "short" -> org.objectweb.asm.Type.SHORT_TYPE;
+            case "int" -> org.objectweb.asm.Type.INT_TYPE;
+            case "char" -> org.objectweb.asm.Type.CHAR_TYPE;
+            case "boolean" -> org.objectweb.asm.Type.BOOLEAN_TYPE;
+            case "double" -> org.objectweb.asm.Type.DOUBLE_TYPE;
+            case "float" -> org.objectweb.asm.Type.FLOAT_TYPE;
+            case "long" -> org.objectweb.asm.Type.LONG_TYPE;
+            case "void" -> org.objectweb.asm.Type.VOID_TYPE;
+            default -> org.objectweb.asm.Type.getType("L" + dotPath.replace('.', '/') + ";");
+        }).getDescriptor();
     }
     
     public static Type[] of(Class<?>... classes) {


### PR DESCRIPTION
Currently, calling the `Type(String dotPath)` constructor with a primitive dot path, like `"void"` or `"int"`, causes an invalid type descriptor to be generated: `Lvoid;` for `"void"`, and `Lint;` for `"int"`, respectively:

![image](https://user-images.githubusercontent.com/52505120/156930531-1c870906-955f-4188-a789-b269124f10cd.png)

This PR fixes the issue by implementing a new, private utility method, `Type.getDescriptor`, which works by simply comparing the dot path to the values for all of the supported primitives, and calling `getDescriptor` on their respective ObjectWeb ASM Type objects:

![image](https://user-images.githubusercontent.com/52505120/156930614-ca863525-81af-40fc-bca9-96b1bf8c8d19.png)