### PR TITLE
Fix stack overflow

### DIFF
--- a/Assembler/src/main/java/mx/kenzie/foundation/assembler/code/CodeElement.java
+++ b/Assembler/src/main/java/mx/kenzie/foundation/assembler/code/CodeElement.java
@@ -135,6 +135,10 @@ public interface CodeElement extends Data, UVec, UnboundedElement {
                 return element.constant();
             }
 
+            @Override
+            public byte[] binary() {
+                return element.binary();
+            }
         }
         //</editor-fold>
         return new WrapperElement(element, increment);
@@ -173,6 +177,10 @@ public interface CodeElement extends Data, UVec, UnboundedElement {
                 return element.constant();
             }
 
+            @Override
+            public byte[] binary() {
+                return element.binary();
+            }
         }
         //</editor-fold>
         return new WrapperElement(element, slot);


### PR DESCRIPTION
Fixes a stack overflow that occurred due to a circular default implementation in `Data#binary()` and `UVec#write(OutputStream)` when compiling code that utilised `CodeElement.incrementStack(CodeElement, int)` or `CodeElement.notifyVariable(CodeElement, int)`.
